### PR TITLE
Remove APPS log4j requirement

### DIFF
--- a/ODPi-Runtime.md
+++ b/ODPi-Runtime.md
@@ -178,8 +178,6 @@ Compliance
 
 -   A common application-architecture is one where there’s a fair bit of stuff running on the “Client Host” -- a Web server, all kinds of app logic, maybe even a database. They interact with Hadoop using client-libraries and cluster-config files installed locally on the client host. These apps tend to have a lot of requirements in terms of the packages installed locally. A good ODPi Platform implementation SHOULD NOT get in the way: at most, the implementation SHOULD only care about the version of Java and Bash, and nothing else.
 
--   ODPi Platforms MUST define the APPS log4j appender to provide ISV and user applications a common definition to log output. The actual definition, location of output, cycling requirements, etc of this appender is not defined by this specification and is ODPi Platform or user- defined. [**TODO: File a JIRA.**]
-
 -   ODPi Platforms SHOULD publish all modified (i.e., not-default) Apache Hadoop configuration entries, regardless of client, server, etc applicability to all nodes unless it is known to be node hardware specific, private to a service, security-sensitive, or otherwise problematic.  The list of variables that SHOULD NOT be shared are defined as:
 
 [**TODO: blacklist**]


### PR DESCRIPTION
Remove the requirement of the APPS log4j.

I think this is going to be controversial to get through Apache.  Additionally, I'm not sure if it is fine grained enough to actually be useful.  There's also the issue of log4j being a long term solution, given that log4j 1.x has been EOLed, leaving Hadoop's direction sort of up in the air.

For now, I think it's better to remove this feature of the spec.
