### PR TITLE
Adding a new SITEXML_VARS specification

### DIFF
--- a/ODPi-Runtime.md
+++ b/ODPi-Runtime.md
@@ -197,7 +197,7 @@ Best practices for ODPi Platforms:
 
 -   **[HADOOP_NORDMPORTS]** ODPi Platforms SHOULD avoid using randomized ports when possible. For example, the NodeManager RPC port SHOULD NOT use the default ‘0’ (or random) value. Using randomized ports may make firewall setup extremely difficult as well as makes some parts of Apache Hadoop function incorrectly.  Be aware that users MAY change these port numbers, including back to randomization.
 
--   **[SITEXML_VARS]** ODPi Platforms SHOULD NOT use variables for values inside sitexml properties which a client must resolve and replace. This requirement assists application integrators by not requiring them to modify sitexmls before they are functional.
+-   **[SITEXML_VARS]** ODPi Platforms SHOULD NOT use variables for values inside sitexml properties which a client must resolve and replace. This requirement assists application integrators by not requiring modification of sitexmls to make them functional.
 
 -   Future versions of this specification MAY require other components to set the environment variable *component*_HOME to the location in which the component is installed and *component*_CONF_DIR to the directory in which the component's configuration can be found, unless the configuration directory is located in *component*_HOME/conf.
 

--- a/ODPi-Runtime.md
+++ b/ODPi-Runtime.md
@@ -197,7 +197,7 @@ Best practices for ODPi Platforms:
 
 -   **[HADOOP_NORDMPORTS]** ODPi Platforms SHOULD avoid using randomized ports when possible. For example, the NodeManager RPC port SHOULD NOT use the default ‘0’ (or random) value. Using randomized ports may make firewall setup extremely difficult as well as makes some parts of Apache Hadoop function incorrectly.  Be aware that users MAY change these port numbers, including back to randomization.
 
--   **[SITEXML_VARS]** ODPi Platforms SHOULD NOT use variables for values inside sitexml properties which a client must resolve and replace.. This requirement assists application integrators by not requiring them to modify sitexmls before they are functional.
+-   **[SITEXML_VARS]** ODPi Platforms SHOULD NOT use variables for values inside sitexml properties which a client must resolve and replace. This requirement assists application integrators by not requiring them to modify sitexmls before they are functional.
 
 -   Future versions of this specification MAY require other components to set the environment variable *component*_HOME to the location in which the component is installed and *component*_CONF_DIR to the directory in which the component's configuration can be found, unless the configuration directory is located in *component*_HOME/conf.
 

--- a/ODPi-Runtime.md
+++ b/ODPi-Runtime.md
@@ -197,6 +197,8 @@ Best practices for ODPi Platforms:
 
 -   **[HADOOP_NORDMPORTS]** ODPi Platforms SHOULD avoid using randomized ports when possible. For example, the NodeManager RPC port SHOULD NOT use the default ‘0’ (or random) value. Using randomized ports may make firewall setup extremely difficult as well as makes some parts of Apache Hadoop function incorrectly.  Be aware that users MAY change these port numbers, including back to randomization.
 
+-   **[SITEXML_VARS]** ODPi Platforms SHOULD NOT use variables for values inside sitexml properties which a client must resolve and replace.. This requirement assists application integrators by not requiring them to modify sitexmls before they are functional.
+
 -   Future versions of this specification MAY require other components to set the environment variable *component*_HOME to the location in which the component is installed and *component*_CONF_DIR to the directory in which the component's configuration can be found, unless the configuration directory is located in *component*_HOME/conf.
 
 Compatibility


### PR DESCRIPTION
This spec came from an issue I run across constantly on Hortonworks' distributions.

In a SAS ACCESS job, the error manifests as ...

```
103        proc hadoop &HDFS_USER. &HDFS_PASS. verbose;
104           mapreduce
105                input='/tmp/sastest'
106                output='/tmp/sastest2'
107                jar=&wordcountjar.
108                outputkey='org.apache.hadoop.io.Text'
109                outputvalue='org.apache.hadoop.io.IntWritable'
110                map='org.apache.hadoop.examples.WordCount$TokenizerMapper';
ERROR: java.lang.IllegalArgumentException: Unable to parse '/hdp/apps/${hdp.version}/mapreduce/mapreduce.tar.gz#mr-framework' as a
       URI, check the setting for mapreduce.application.framework.path
ERROR:  at org.apache.hadoop.mapreduce.JobSubmitter.addMRFrameworkToDistributedCache(JobSubmitter.java:443)
ERROR:  at org.apache.hadoop.mapreduce.JobSubmitter.submitJobInternal(JobSubmitter.java:142)
ERROR:  at org.apache.hadoop.mapreduce.Job$10.run(Job.java:1290)
ERROR:  at org.apache.hadoop.mapreduce.Job$10.run(Job.java:1287)
ERROR:  at java.security.AccessController.doPrivileged(Native Method)
ERROR:  at javax.security.auth.Subject.doAs(Subject.java:415)
ERROR:  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1657)
ERROR:  at org.apache.hadoop.mapreduce.Job.submit(Job.java:1287)
ERROR:  at com.dataflux.hadoop.DFHadoopMapReduce$1.run(DFHadoopMapReduce.java:425)
ERROR:  at java.security.AccessController.doPrivileged(Native Method)
ERROR:  at javax.security.auth.Subject.doAs(Subject.java:415)
ERROR:  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1657)
ERROR:  at com.dataflux.hadoop.DFHadoopMapReduce.runMapReduce(DFHadoopMapReduce.java:311)
ERROR: Caused by: java.net.URISyntaxException: Illegal character in path at index 11:
       /hdp/apps/${hdp.version}/mapreduce/mapreduce.tar.gz#mr-framework
ERROR:  at java.net.URI$Parser.fail(URI.java:2829)
ERROR:  at java.net.URI$Parser.checkChars(URI.java:3002)
ERROR:  at java.net.URI$Parser.parseHierarchical(URI.java:3086)
ERROR:  at java.net.URI$Parser.parse(URI.java:3044)
ERROR:  at java.net.URI.<init>(URI.java:595)
ERROR:  at org.apache.hadoop.mapreduce.JobSubmitter.addMRFrameworkToDistributedCache(JobSubmitter.java:441)
ERROR:  ... 12 more
111        run;
```

The root cause of the problem is the string '${hdp.version}' inside mapred-site.xml ...

``` sh
[root@sandbox hadoop-tracer]# fgrep -B1 'hdp.version' /etc/hadoop/conf/*.xml                                           
/etc/hadoop/conf/mapred-site.xml-      <name>mapreduce.admin.map.child.java.opts</name>
/etc/hadoop/conf/mapred-site.xml:      <value>-server -XX:NewRatio=8 -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}</value>
--
/etc/hadoop/conf/mapred-site.xml-      <name>mapreduce.admin.reduce.child.java.opts</name>
/etc/hadoop/conf/mapred-site.xml:      <value>-server -XX:NewRatio=8 -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}</value>
--
/etc/hadoop/conf/mapred-site.xml-      <name>mapreduce.admin.user.env</name>
/etc/hadoop/conf/mapred-site.xml:      <value>LD_LIBRARY_PATH=/usr/hdp/${hdp.version}/hadoop/lib/native:/usr/hdp/${hdp.version}/hadoop/lib/native/Linux-amd64-64</value>
--
/etc/hadoop/conf/mapred-site.xml-      <name>mapreduce.application.classpath</name>
/etc/hadoop/conf/mapred-site.xml:      <value>$PWD/mr-framework/hadoop/share/hadoop/mapreduce/*:$PWD/mr-framework/hadoop/share/hadoop/mapreduce/lib/*:$PWD/mr-framework/hadoop/share/hadoop/common/*:$PWD/mr-framework/hadoop/share/hadoop/common/lib/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/lib/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*:$PWD/mr-framework/hadoop/share/hadoop/tools/lib/*:/usr/hdp/${hdp.version}/hadoop/lib/hadoop-lzo-0.6.0.${hdp.version}.jar:/etc/hadoop/conf/secure</value>
--
/etc/hadoop/conf/mapred-site.xml-      <name>mapreduce.application.framework.path</name>
/etc/hadoop/conf/mapred-site.xml:      <value>/hdp/apps/${hdp.version}/mapreduce/mapreduce.tar.gz#mr-framework</value>
--
/etc/hadoop/conf/mapred-site.xml-      <name>yarn.app.mapreduce.am.admin-command-opts</name>
/etc/hadoop/conf/mapred-site.xml:      <value>-Dhdp.version=${hdp.version}</value>
```

I have found evidence that SAS is not the only company dealing with this issue:
https://datameer.zendesk.com/hc/en-us/articles/205344280-java-lang-IllegalArgumentException-Unable-to-parse-check-settings-for-mapreduce-application-framework-path
https://issues.apache.org/jira/browse/AMBARI-8028
